### PR TITLE
Fix container width on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,10 +20,19 @@ body {
 
 .container {
   width: 100%;
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0 1rem;
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 1rem;
+  }
 }
 
 .section {


### PR DESCRIPTION
## Summary
- make containers span the entire viewport on mobile
- add desktop layout styles for container

## Testing
- `npm run build` *(fails: astro not found)*