### PR TITLE
Add sticky responsive navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,0 +1,23 @@
+---
+---
+<nav class="navbar">
+  <div class="container">
+    <a href="#" class="logo">
+      <img src="/alpakafarm.svg" alt="Alpakasölde Logo" />
+    </a>
+    <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
+    <ul class="nav-links">
+      <li><a href="#leistungen">Leistungen</a></li>
+      <li><a href="#alpakas">Alpakas</a></li>
+      <li><a href="#ueber-uns">Über uns</a></li>
+      <li><a href="#kontakt">Kontakt</a></li>
+    </ul>
+  </div>
+  <script>
+    const toggle = document.querySelector('.nav-toggle');
+    const links = document.querySelector('.nav-links');
+    toggle.addEventListener('click', () => {
+      links.classList.toggle('open');
+    });
+  </script>
+</nav>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Navbar from "../components/Navbar.astro";
 
 interface Props {
 	title: string;
@@ -48,6 +49,7 @@ const { title } = Astro.props;
 		</script>
 	</head>
         <body>
+                <Navbar />
                 <slot />
         </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -226,3 +226,61 @@ body {
   }
 }
 
+
+/* Navigation */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--vanilla-cream);
+  padding: 0.5rem 0;
+}
+
+.navbar .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--slate-river);
+  font-weight: 600;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    background-color: var(--vanilla-cream);
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 1rem;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new Navbar component with links to page sections
- insert the Navbar in the Layout
- style the navigation bar for sticky positioning and mobile responsiveness

## Testing
- `npm run build` *(fails: astro not found)*