### PR TITLE
Fix navbar sticky layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,11 +55,10 @@ const { title } = Astro.props;
 </html>
 
 <style>
-	html,
-	body {
-		margin: 0;
-		width: 100%;
-		height: 100%;
-	}
+        html,
+        body {
+                margin: 0;
+                width: 100%;
+        }
 </style>
 


### PR DESCRIPTION
## Summary
- remove body height from global layout so navbar stays sticky

## Testing
- `npm run build` *(fails: astro not found)*