### PR TITLE
Fix mobile nav closing

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -16,8 +16,14 @@
   <script>
     const toggle = document.querySelector('.nav-toggle');
     const links = document.querySelector('.nav-links');
+    const linkItems = document.querySelectorAll('.nav-links a');
     toggle.addEventListener('click', () => {
       links.classList.toggle('open');
+    });
+    linkItems.forEach((item) => {
+      item.addEventListener('click', () => {
+        links.classList.remove('open');
+      });
     });
   </script>
 </nav>


### PR DESCRIPTION
## Summary
- close the mobile navigation menu when any navigation link is clicked

## Testing
- `npm run build` *(fails: astro not found)*