### PR TITLE
Add profile pictures for alpacas

### DIFF
--- a/src/components/Alpacas.astro
+++ b/src/components/Alpacas.astro
@@ -2,22 +2,27 @@
   <h2>Unsere Alpakas</h2>
   <div class="alpaca-grid container">
     <div class="alpaca-item">
+      <img src="/amadeus.JPG" alt="Amadeus" class="alpaca-photo" />
       <h3>Amadeus</h3>
       <p>Der ruhige Anführer der Herde, benannt nach Mozart.</p>
     </div>
     <div class="alpaca-item">
+      <img src="/ludwig.JPG" alt="Ludwig" class="alpaca-photo" />
       <h3>Ludwig</h3>
       <p>Lebhaft und neugierig, wie Beethovens Musik.</p>
     </div>
     <div class="alpaca-item">
+      <img src="/johann.JPG" alt="Johann" class="alpaca-photo" />
       <h3>Johann</h3>
       <p>Harmonisch und ausgeglichen, unser kleiner Bach.</p>
     </div>
     <div class="alpaca-item">
+      <img src="/richard.JPG" alt="Richard" class="alpaca-photo" />
       <h3>Richard</h3>
       <p>Stolz und majestätisch, wie Wagners Opern.</p>
     </div>
     <div class="alpaca-item">
+      <img src="/antonio.HEIC" alt="Antonio" class="alpaca-photo" />
       <h3>Antonio</h3>
       <p>Spritzig und freundlich, inspiriert von Vivaldi.</p>
     </div>
@@ -33,6 +38,14 @@
   .alpaca-item {
     padding: 1rem;
     text-align: center;
+  }
+
+  .alpaca-photo {
+    width: 8rem;
+    height: 8rem;
+    object-fit: cover;
+    border-radius: 50%;
+    margin-bottom: 0.75rem;
   }
 
   @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- show the alpaca images in `Alpacas.astro`
- style them as round profile pictures

## Testing
- `npm run build` *(fails: astro not found)*