### PR TITLE
Fix services text color

### DIFF
--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -19,6 +19,7 @@
 <style>
   .services {
     background-color: var(--forest-fern);
+    color: var(--vanilla-cream);
   }
 
   .services-grid {


### PR DESCRIPTION
## Summary
- make the text color in `Services` match the light contact style

## Testing
- `npm run build` *(fails: astro not found)*