### PR TITLE
Improve slideshow for portrait images

### DIFF
--- a/src/components/Slideshow.astro
+++ b/src/components/Slideshow.astro
@@ -29,19 +29,23 @@ const images = [
     position: relative;
     width: 100%;
     overflow: hidden;
-    height: 16rem;
+    height: 24rem;
   }
 
   @media (min-width: 768px) {
     .slideshow {
-      height: 24rem;
+      height: 32rem;
     }
   }
 
   .slide {
     position: absolute;
     inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     transition: opacity 1s;
+    background-color: var(--vanilla-cream);
   }
 
   .slide.hidden {
@@ -53,8 +57,10 @@ const images = [
   }
 
   .slide img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    object-fit: contain;
   }
 </style>


### PR DESCRIPTION
## Summary
- adjust slide heights for more space
- center each slide with `object-fit: contain`
- ensure slides have a clean background color

## Testing
- `npm run build` *(fails: astro not found)*