### PR TITLE
Fix .NET Azure Function configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,11 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "./dist" # App source code path
-          api_location: "./api_output" # Api source code path - optional
-          output_location: "." # Built app content directory - optional
+          app_location: "/" # App source code path
+          output_location: "dist" # Built app content directory
+          api_location: "./api_output" # Published API path
+          skip_api_build: true
+          skip_app_build: true
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          output_location: "dist" # Built app content directory
+          app_location: "./dist" # App source code path
           api_location: "./api_output" # Published API path
+          output_location: "." # Built app content directory
           skip_api_build: true
           skip_app_build: true
           ###### End of Repository/Build Configurations ######

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           app_location: "./dist" # App source code path
           api_location: "./api_output" # Published API path
           output_location: "." # Built app content directory
+          config_file_location: "/"
           skip_api_build: true
           skip_app_build: true
           ###### End of Repository/Build Configurations ######

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,8 +1,6 @@
 {
-  "app_settings": [
-    {
-      "name": "FUNCTIONS_WORKER_RUNTIME",
-      "value": "dotnet-isolated"
-    }
-  ]
+  "platform": {
+    "apiRuntime": "dotnet-isolated:9.0"
+  }
 }
+

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,8 @@
+{
+  "app_settings": [
+    {
+      "name": "FUNCTIONS_WORKER_RUNTIME",
+      "value": "dotnet-isolated"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add app settings so Azure Static Web Apps uses dotnet isolated runtime
- adjust deployment workflow to skip automatic builds and point to the right directories

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `dotnet build Api/Api.csproj -c Release` *(fails: command not found)*