### PR TITLE
Add table storage bicep deployment

### DIFF
--- a/.github/workflows/deploy-storage.yml
+++ b/.github/workflows/deploy-storage.yml
@@ -1,0 +1,22 @@
+name: Deploy Table Storage
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Deploy Bicep
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az deployment group create \
+              --subscription 8c599ae4-ed4f-43ba-9754-0a380ea6f0e1 \
+              --resource-group RG-Alpakasoelde \
+              --template-file infrastructure/table-storage.bicep

--- a/infrastructure/table-storage.bicep
+++ b/infrastructure/table-storage.bicep
@@ -1,0 +1,27 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the storage account to create')
+param storageAccountName string = 'alpakasoeldetables'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageAccountName
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+  }
+}
+
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2022-09-01' = {
+  name: '${storageAccount.name}/default'
+  dependsOn: [
+    storageAccount
+  ]
+}
+
+output storageAccountName string = storageAccount.name


### PR DESCRIPTION
## Summary
- create infrastructure with a Bicep template for a table storage account
- add a workflow that deploys the template on manual trigger

## Testing
- `npm run build` *(fails: astro not found)*