### PR TITLE
Convert color codes table to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,58 @@
 # Alpakasoelde 🦙
 
-The homepage of our alpaca farm.  
+The homepage of our alpaca farm.
 [Take a look](https://alpakasoelde.at)
 
 ## Color codes to use
 
-| Hex     | Name          |
-| ------- | ------------- |
-| #E7AA4F | Warm Honey    |
-| #FDF6EE | Vanilla Cream |
-| #A7B64F | Olive Leaf    |
-| #7399C0 | Dusty Sky     |
-| #E58150 | Sunset Coral  |
-| #97C8C4 | Seafoam Mist  |
-| #568468 | Forest Fern   |
-| #3D5464 | Slate River   |
+<table>
+  <thead>
+    <tr>
+      <th>Preview</th>
+      <th>Hex</th>
+      <th>Name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="background:#E7AA4F;width:1.5em;height:1.5em;"></td>
+      <td>#E7AA4F</td>
+      <td>Warm Honey</td>
+    </tr>
+    <tr>
+      <td style="background:#FDF6EE;width:1.5em;height:1.5em;"></td>
+      <td>#FDF6EE</td>
+      <td>Vanilla Cream</td>
+    </tr>
+    <tr>
+      <td style="background:#A7B64F;width:1.5em;height:1.5em;"></td>
+      <td>#A7B64F</td>
+      <td>Olive Leaf</td>
+    </tr>
+    <tr>
+      <td style="background:#7399C0;width:1.5em;height:1.5em;"></td>
+      <td>#7399C0</td>
+      <td>Dusty Sky</td>
+    </tr>
+    <tr>
+      <td style="background:#E58150;width:1.5em;height:1.5em;"></td>
+      <td>#E58150</td>
+      <td>Sunset Coral</td>
+    </tr>
+    <tr>
+      <td style="background:#97C8C4;width:1.5em;height:1.5em;"></td>
+      <td>#97C8C4</td>
+      <td>Seafoam Mist</td>
+    </tr>
+    <tr>
+      <td style="background:#568468;width:1.5em;height:1.5em;"></td>
+      <td>#568468</td>
+      <td>Forest Fern</td>
+    </tr>
+    <tr>
+      <td style="background:#3D5464;width:1.5em;height:1.5em;"></td>
+      <td>#3D5464</td>
+      <td>Slate River</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- convert color code table in README to HTML
- add preview column showing each color

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6839fb01d4088327837cb66ab5f1900a