### PR TITLE
Improve heading readability

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,15 @@ body {
   margin: 0;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #000;
+}
+
 .container {
   width: 100%;
   max-width: 1200px;


### PR DESCRIPTION
## Summary
- set all heading text to black for better contrast

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ac3393a4883278582aa450317c5bb