### PR TITLE
Fix location icons in contact component

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -20,8 +20,8 @@
     <!-- Redesigned “Standort” block starts here -->
     <aside class="contact-address">
       <header>
-        <svg width="24" height="24" fill="currentColor" aria-hidden="true">
-          <path d="M12 2a7 7 0 00-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 00-7-7z"/>
+        <svg width="24" height="24" fill="currentColor" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z"/>
         </svg>
         <h3>Standort</h3>
       </header>


### PR DESCRIPTION
## Summary
- use a single location icon in the contact address header

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b093399088327b6203d6a43fe6431