### PR TITLE
Fix arrow overlapping text in Services component

### DIFF
--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -36,7 +36,7 @@
   .service-item {
     display: block;
     position: relative;
-    padding: 1.5rem 1rem;
+    padding: 1.5rem 2.25rem 1.5rem 1rem;
     text-align: center;
     background-color: var(--vanilla-cream);
     color: var(--slate-river);


### PR DESCRIPTION
## Summary
- widen right padding in Services component so the arrow no longer covers the description text

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b137d66648327921296b7409fc54a