### PR TITLE
Harmonise service & alpaca sections

### DIFF
--- a/src/components/Alpacas.astro
+++ b/src/components/Alpacas.astro
@@ -30,6 +30,12 @@
 </section>
 
 <style>
+  .alpacas {
+    /* match color scheme of the contact section */
+    background-color: var(--dusty-sky);
+    color: var(--vanilla-cream);
+  }
+
   .alpaca-grid {
     display: grid;
     gap: 2rem;
@@ -38,6 +44,10 @@
   .alpaca-item {
     padding: 1rem;
     text-align: center;
+    background-color: var(--vanilla-cream);
+    color: var(--slate-river);
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   }
 
   .alpaca-photo {

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -24,7 +24,8 @@
 
 <style>
   .services {
-    background-color: var(--forest-fern);
+    /* align colors with the contact section */
+    background-color: var(--dusty-sky);
     color: var(--vanilla-cream);
   }
 
@@ -41,6 +42,7 @@
     background-color: var(--vanilla-cream);
     color: var(--slate-river);
     border-radius: 0.5rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
     text-decoration: none;
     transition: background-color 0.2s, color 0.2s;
   }


### PR DESCRIPTION
## Summary
- align `Services` and `Alpacas` sections with the card look of the contact section
- switch background color to `dusty-sky` and use card shadows

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b13e06ea083278777dc1d2ad98c50