### PR TITLE
Fix arrow overlay in Services component

### DIFF
--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -36,7 +36,7 @@
   .service-item {
     display: block;
     position: relative;
-    padding: 1.5rem 1rem;
+    padding: 1.5rem 2rem 1.5rem 1rem;
     text-align: center;
     color: var(--vanilla-cream);
     border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- adjust `padding-right` in the service link items so the arrow no longer overlaps the text

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b19110f5c8327923c88ebcfc1511c