### PR TITLE
Fix logo to link back to main page

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,7 +2,7 @@
 ---
 <nav class="navbar">
   <div class="container">
-    <a href="#" class="logo">
+    <a href="/" class="logo">
       <img style="width:60px;height:60px" src="/alpakasoelde-logo.svg" alt="Alpakasölde Logo" />
     </a>
     <button class="nav-toggle" aria-label="Menü öffnen">☰</button>


### PR DESCRIPTION
## Summary
- adjust Navbar logo link to point to root of the site

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b1978dd10832785478d8131a1d8e2