### PR TITLE
Add details and slideshow for Alpaka Wanderungen

### DIFF
--- a/src/components/Slideshow.astro
+++ b/src/components/Slideshow.astro
@@ -1,13 +1,20 @@
 ---
-const images = [
+interface Props {
+  images?: string[];
+}
+
+const defaultImages = [
   '/slideshow1.jpg',
   '/slideshow2.jpg',
   '/slideshow3.jpg',
   '/slideshow4.jpg'
 ];
+
+const { images } = Astro.props as Props;
+const slideshowImages = images ?? defaultImages;
 ---
 <ul class="slideshow" id="slideshow">
-  {images.map((src, i) => (
+  {slideshowImages.map((src, i) => (
     <li class={`slide ${i === 0 ? 'visible' : 'hidden'}`} image-slide>
       <img src={src} alt="Alpaka auf der Alpakasölde Farm" />
     </li>

--- a/src/pages/alpaka-wanderungen.astro
+++ b/src/pages/alpaka-wanderungen.astro
@@ -1,5 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import Slideshow from '../components/Slideshow.astro';
+
+const images = [
+  '/amadeus.JPG',
+  '/ludwig.JPG',
+  '/johann.JPG',
+  '/richard.JPG'
+];
 ---
 
 <Layout title="Alpaka-Wanderungen">
@@ -12,11 +20,37 @@ import Layout from '../layouts/Layout.astro';
       </p>
     </div>
   </section>
+
+  <Slideshow images={images} />
+
+  <section class="details section">
+    <div class="container">
+      <h3>Details</h3>
+      <p>
+        Bei einer gemütlichen Runde über unsere Felder lernst du die Tiere
+        kennen und kannst die Landschaft genießen.
+      </p>
+      <ul class="details-list">
+        <li><strong>Preis:</strong> 30&nbsp;€ pro Person</li>
+        <li><strong>Dauer:</strong> ca. 2&nbsp;Stunden</li>
+        <li><strong>Hinweis:</strong> Hunde können leider nicht mitwandern</li>
+      </ul>
+    </div>
+  </section>
 </Layout>
 
 <style>
   .service-page {
     background-color: var(--seafoam-mist);
     color: var(--slate-river);
+  }
+
+  .details-list {
+    list-style: none;
+    padding: 0;
+  }
+
+  .details-list li {
+    margin-bottom: 0.5rem;
   }
 </style>


### PR DESCRIPTION
## Summary
- allow slideshow to receive custom image list
- extend Alpaka-Wanderungen page with slideshow and detailed info

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b1a4b725c832792616056c13f4793