### PR TITLE
Add info box for excursion tips

### DIFF
--- a/src/pages/alpaka-wanderungen.astro
+++ b/src/pages/alpaka-wanderungen.astro
@@ -17,9 +17,7 @@ const images = [
       <p>
         Entdecke bei einer Wanderung durch die Inn Auen die Natur an der Seite
         unserer freundlichen Alpakas. Ein Hofbesuch mit Kennenlernen der Tiere
-        ist inklusive. Danach bietet sich eine Einkehr in der Burgschänke
-        Frauenstein an. Der Ausflug lässt sich auch mit einem Besuch des
-        Naturiums in Ering verbinden, wo Vogelkunde vermittelt wird.
+        ist inklusive.
       </p>
     </div>
   </section>
@@ -41,6 +39,20 @@ const images = [
         </ul>
     </div>
   </section>
+
+  <section class="info-box section">
+    <div class="container">
+      <h3>Ausflugstipps</h3>
+      <p>
+        Für eine Stärkung nach der Wanderung empfiehlt sich die
+        <a href="https://www.burgschaenke-frauenstein.at" class="link" target="_blank" rel="noopener noreferrer">Burgschenke Frauenstein</a>
+        mit regionaler Küche und gemütlichem Gastgarten. Ganz in der Nähe liegt das
+        <a href="https://www.naturium-ering.at" class="link" target="_blank" rel="noopener noreferrer">Naturium Ering</a>.
+        Dort erhältst du spannende Einblicke in die Vogelwelt des Europareservats Unterer Inn
+        und kannst von Aussichtstürmen seltene Arten beobachten.
+      </p>
+    </div>
+  </section>
 </Layout>
 
 <style>
@@ -56,5 +68,11 @@ const images = [
 
   .details-list li {
     margin-bottom: 0.5rem;
+  }
+
+  .info-box {
+    background-color: var(--dusty-sky);
+    color: var(--vanilla-cream);
+    text-align: center;
   }
 </style>


### PR DESCRIPTION
## Summary
- create a small info box at the end of the Alpaka-Wanderungen page
- link to Burgschenke Frauenstein and Naturium Ering and remove those hints from the intro text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b3be5247c83279a323c7ff3b906d4