### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'Api/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'Api/**'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- limit CI workflow to run only when `src`, `public`, `Api` or the workflow file change

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b456cb9048327934650ae93f01a38