### PR TITLE
Fix excursion tips layout

### DIFF
--- a/src/pages/alpaka-wanderungen.astro
+++ b/src/pages/alpaka-wanderungen.astro
@@ -49,7 +49,10 @@ const images = [
       <p>
         Für eine Stärkung nach der Wanderung empfiehlt sich die
         <a href="https://www.burgschaenke-frauenstein.at" class="link" target="_blank" rel="noopener noreferrer">Burgschenke Frauenstein</a>
-        mit regionaler Küche und gemütlichem Gastgarten. Ganz in der Nähe liegt das
+        mit regionaler Küche und gemütlichem Gastgarten.
+      </p>
+      <p>
+        Ganz in der Nähe liegt das
         <a href="https://www.naturium-ering.at" class="link" target="_blank" rel="noopener noreferrer">Naturium Ering</a>.
         Dort erhältst du spannende Einblicke in die Vogelwelt des Europareservats Unterer Inn
         und kannst von Aussichtstürmen seltene Arten beobachten.


### PR DESCRIPTION
## Summary
- split excursion tips for the alpaca hike page into two paragraphs

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b46d28d288327af9fc65c829c07cc