### PR TITLE
Add contact success redirect

### DIFF
--- a/Api/SendMessageFunction.cs
+++ b/Api/SendMessageFunction.cs
@@ -65,9 +65,9 @@ public class SendMessageFunction(ILoggerFactory loggerFactory)
             };
         }
 
-        // Create the HTTP 200 OK response with a simple "ok" payload
-        var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
-        await response.WriteStringAsync("ok").ConfigureAwait(false);
+        // Return a redirect so the user sees the thank you page after submitting
+        var response = req.CreateResponse(System.Net.HttpStatusCode.SeeOther);
+        response.Headers.Add("Location", "/kontakt-erfolgreich");
 
         MessageEntity messageEntity = new(name, email, messageContent);
 

--- a/src/pages/kontakt-erfolgreich.astro
+++ b/src/pages/kontakt-erfolgreich.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Kontakt Erfolgreich">
+  <section class="service-page section">
+    <div class="container">
+      <h2>Vielen Dank für deine Nachricht!</h2>
+      <p>Wir melden uns so schnell wie möglich bei dir.</p>
+      <p style="text-align:center;margin-top:2rem;">
+        <a href="/" class="btn">Zurück zur Startseite</a>
+      </p>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .service-page {
+    background-color: var(--seafoam-mist);
+    color: var(--slate-river);
+    text-align: center;
+  }
+</style>


### PR DESCRIPTION
## Summary
- redirect send-message API to new thank-you page
- add `kontakt-erfolgreich` Astro page with return link

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f03c0695c832795208ba0e81c455a