### PR TITLE
Change contact success page URL

### DIFF
--- a/Api/SendMessageFunction.cs
+++ b/Api/SendMessageFunction.cs
@@ -67,7 +67,7 @@ public class SendMessageFunction(ILoggerFactory loggerFactory)
 
         // Return a redirect so the user sees the thank you page after submitting
         var response = req.CreateResponse(System.Net.HttpStatusCode.SeeOther);
-        response.Headers.Add("Location", "/kontakt-erfolgreich");
+        response.Headers.Add("Location", "/nachricht-gesendet");
 
         MessageEntity messageEntity = new(name, email, messageContent);
 

--- a/src/pages/nachricht-gesendet.astro
+++ b/src/pages/nachricht-gesendet.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Kontakt Erfolgreich">
+<Layout title="Nachricht gesendet">
   <section class="service-page section">
     <div class="container">
       <h2>Vielen Dank für deine Nachricht!</h2>


### PR DESCRIPTION
## Summary
- rename `kontakt-erfolgreich` page to `nachricht-gesendet`
- update redirect in API

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f57e28f9883278dd62c5ddd5b2599