### PR TITLE
Use TableClient for message storage

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.17.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Tables" Version="1.4.3" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
   </ItemGroup>
 </Project>

--- a/Api/SendMessageFunction.cs
+++ b/Api/SendMessageFunction.cs
@@ -94,14 +94,14 @@ public class SendMessageFunction(ILoggerFactory loggerFactory)
             return badRequestResponse;
         }
 
-        var response = req.CreateResponse(System.Net.HttpStatusCode.SeeOther);
-        response.Headers.Add("Location", "/nachricht-gesendet");
-
         MessageEntity messageEntity = new(name!, email!, messageContent!);
 
         string? connectionString = Environment.GetEnvironmentVariable("MessageStorageConnection");
-        var tableClient = new TableClient(connectionString, "messages");
+        TableClient tableClient = new(connectionString, "messages");
         await tableClient.AddEntityAsync(messageEntity).ConfigureAwait(false);
+
+        var response = req.CreateResponse(System.Net.HttpStatusCode.SeeOther);
+        response.Headers.Add("Location", "/nachricht-gesendet");
 
         return response;
     }


### PR DESCRIPTION
## Summary
- remove Table storage binding
- write messages directly using `TableClient`
- add Azure.Data.Tables dependency

## Testing
- `dotnet build alpakasoelde.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fd8dc3b488327ad856c7169bab4c3