### PR TITLE
Add admin messages page

### DIFF
--- a/src/pages/admin/messages.astro
+++ b/src/pages/admin/messages.astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+const messages = [
+  { name: 'Anna Beispiel', email: 'anna@example.com', text: 'Hallo, ich interessiere mich f\xFCr eine Alpaka-Wanderung.' },
+  { name: 'Bernd Muster', email: 'bernd@example.com', text: 'Wann finden die n\xE4chsten Workshops statt?' },
+  { name: 'Carla Demo', email: 'carla@example.com', text: 'K\xF6nnen wir euch spontan besuchen?' },
+  { name: 'David Test', email: 'david@example.com', text: 'Ich m\xF6chte Wolle bestellen.' }
+];
+---
+
+<Layout title="Nachrichten">
+  <section class="admin-page section">
+    <div class="container">
+      <h2>Eingegangene Nachrichten</h2>
+      <ul class="message-list">
+        {messages.map(msg => (
+          <li class="message" key={msg.email}>
+            <h3>{msg.name} <span class="email">({msg.email})</span></h3>
+            <p>{msg.text}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .admin-page {
+    background-color: var(--seafoam-mist);
+    color: var(--slate-river);
+  }
+
+  .message-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .message {
+    background: var(--vanilla-cream);
+    color: var(--slate-river);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .email {
+    font-weight: normal;
+    font-size: 0.875rem;
+  }
+</style>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -20,7 +20,12 @@
         "404": {
             "rewrite": "/404.html",
             "statusCode": 404
+        },
+        "401": {
+            "statusCode": 302,
+            "redirect": "/.auth/login/github?post_login_redirect_uri=.referrer"
         }
+    },
   },
   "platform": {
     "apiRuntime": "dotnet-isolated:9.0"

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -25,7 +25,7 @@
             "statusCode": 302,
             "redirect": "/.auth/login/github?post_login_redirect_uri=.referrer"
         }
-    },
+    }
   },
   "platform": {
     "apiRuntime": "dotnet-isolated:9.0"

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -17,14 +17,13 @@
     }
   ],
   "responseOverrides": {
-        "404": {
-            "rewrite": "/404.html",
-            "statusCode": 404
-        },
-        "401": {
-            "statusCode": 302,
-            "redirect": "/.auth/login/github?post_login_redirect_uri=.referrer"
-        }
+    "404": {
+        "rewrite": "/404.html",
+        "statusCode": 404
+    },
+    "401": {
+        "statusCode": 302,
+        "redirect": "/.auth/login/github?post_login_redirect_uri=.referrer"
     }
   },
   "platform": {

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,4 +1,21 @@
 {
+  "auth": {
+    "identityProviders": {
+      "github": {}
+    }
+  },
+  "routes": [
+    {
+      "route": "/admin/*",
+      "allowedRoles": ["admin"]
+    },
+    {
+      "route": "/*",
+      "serve": "/index.html",
+      "statusCode": 200,
+      "allowedRoles": ["anonymous", "authenticated"]
+    }
+  ],
   "responseOverrides": {
         "404": {
             "rewrite": "/404.html",


### PR DESCRIPTION
## Summary
- add a new `/admin/messages` page showing dummy messages

## Testing
- `npm run build` *(fails: astro not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68414897fb308327b8b676e21cec6459