### PR TITLE
Modernize admin messages list

### DIFF
--- a/src/pages/admin/messages.astro
+++ b/src/pages/admin/messages.astro
@@ -6,21 +6,9 @@ import Layout from '../../layouts/Layout.astro';
   <section class="admin-page section">
     <div class="container">
       <h2>Eingegangene Nachrichten</h2>
-      <table class="message-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Nachricht</th>
-            <th>Zeitpunkt</th>
-          </tr>
-        </thead>
-        <tbody id="message-table-body">
-          <tr>
-            <td colspan="4">Lade Nachrichten...</td>
-          </tr>
-        </tbody>
-      </table>
+      <div id="message-list" class="message-list">
+        <p>Lade Nachrichten...</p>
+      </div>
     </div>
   </section>
 </Layout>
@@ -31,15 +19,22 @@ import Layout from '../../layouts/Layout.astro';
       const res = await fetch('/api/get-messages');
       if (!res.ok) return;
       const msgs = await res.json();
-      const tbody = document.getElementById('message-table-body');
-      tbody.innerHTML = '';
+      const list = document.getElementById('message-list');
+      list.innerHTML = '';
       msgs.forEach((msg) => {
-        const tr = document.createElement('tr');
+        const card = document.createElement('article');
+        card.className = 'message-card';
         const time = new Date(msg.Timestamp).toLocaleString('de-AT', {
           timeZone: 'Europe/Vienna',
         });
-        tr.innerHTML = `<td>${msg.Name}</td><td>${msg.Email}</td><td>${msg.Message}</td><td>${time}</td>`;
-        tbody.appendChild(tr);
+        card.innerHTML = `\
+          <header class="message-header">\
+            <h3 class="message-sender">${msg.Name}</h3>\
+            <a class="message-email" href="mailto:${msg.Email}">${msg.Email}</a>\
+            <time class="message-time">${time}</time>\
+          </header>\
+          <p class="message-text">${msg.Message}</p>`;
+        list.appendChild(card);
       });
     } catch {
       /* ignore */
@@ -54,20 +49,46 @@ import Layout from '../../layouts/Layout.astro';
     color: var(--slate-river);
   }
 
-  .message-table {
-    width: 100%;
-    border-collapse: collapse;
+  .message-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 
-  .message-table th,
-  .message-table td {
-    padding: 0.5rem;
-    border: 1px solid var(--slate-river);
-    text-align: left;
+  .message-card {
+    background: var(--vanilla-cream);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   }
 
-  .message-table th {
-    background: var(--dusty-sky);
-    color: var(--vanilla-cream);
+  .message-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .message-sender {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  .message-email {
+    color: var(--slate-river);
+  }
+
+  .message-time {
+    margin-left: auto;
+    font-size: 0.875rem;
+    color: var(--slate-river);
+  }
+
+  .message-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 </style>


### PR DESCRIPTION
## Summary
- redesign the admin messages page to show messages in cards instead of a table
- make styles mobile friendly and allow messages up to 2000 characters

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build Api/Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841976289c88327a7f02485c4edf22c