### PR TITLE
Add admin dashboard page

### DIFF
--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,31 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+
+<Layout title="Admin Dashboard">
+  <section class="admin-page section">
+    <div class="container">
+      <h2>Dashboard</h2>
+      <ul class="admin-links">
+        <li><a class="btn" href="/admin/messages">Nachrichten</a></li>
+      </ul>
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .admin-page {
+    background-color: var(--seafoam-mist);
+    color: var(--slate-river);
+    text-align: center;
+  }
+
+  .admin-links {
+    list-style: none;
+    padding: 0;
+  }
+
+  .admin-links li {
+    margin-bottom: 1rem;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add admin dashboard under `/admin` with a link to messages

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_684197f9e1e08327847d48c631e2893e