### PR TITLE
Add Bricolage Grotesque font

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -208,7 +208,7 @@
   .contact-address h3 {
     margin: 0;
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: 400;
   }
 
   /* ===== map styling (unchanged) ===== */

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -29,7 +29,7 @@ import Logo from '../images/alpakasoelde-logo.svg';
 
   .hero h1 {
     font-size: 3rem;
-    font-weight: bold;
+    font-weight: 400;
     margin-bottom: 1rem;
   }
 

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -64,7 +64,7 @@
 
   .service-item h3 {
     font-size: 1.25rem;
-    font-weight: 600;
+    font-weight: 400;
     margin-bottom: 0.5rem;
   }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,8 +17,11 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
                 <link rel="icon" type="image/svg+xml" href={Favicon.src} />
-		<meta name="generator" content={Astro.generator} />
+                <meta name="generator" content={Astro.generator} />
                 <title>{title} | Alpakasölde</title>
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400&display=swap" rel="stylesheet" />
 		
                 <!-- SEO Meta Tags -->
                 <meta name="description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,8 @@
 body {
   background-color: var(--vanilla-cream);
   color: var(--slate-river);
-  font-family: sans-serif;
+  font-family: "Bricolage Grotesque", sans-serif;
+  font-weight: 300;
   margin: 0;
 }
 
@@ -35,8 +36,12 @@ body {
 .section h2 {
   text-align: center;
   font-size: 1.875rem;
-  font-weight: bold;
+  font-weight: 400;
   margin-bottom: 2rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 400;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- add Google Font links in Layout
- use Bricolage Grotesque as the default font
- lighten body text and keep headings regular
- adjust heading weights in Hero, Services and Contact components

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841bdaa56c083278579faf7e9545272