### PR TITLE
Add admin-specific navbar

### DIFF
--- a/src/components/AdminNavbar.astro
+++ b/src/components/AdminNavbar.astro
@@ -1,0 +1,122 @@
+---
+---
+<nav class="navbar">
+  <div class="container">
+    <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
+    <ul class="nav-links">
+      <li><a href="/admin/messages">Messages</a></li>
+    </ul>
+    <div class="user-info">
+      <span class="user-name"></span>
+      <img class="avatar" alt="" />
+    </div>
+  </div>
+  <script>
+    const toggle = document.querySelector('.nav-toggle');
+    const links = document.querySelector('.nav-links');
+    const user = document.querySelector('.user-info');
+    toggle.addEventListener('click', () => {
+      links.classList.toggle('open');
+      user.classList.toggle('open');
+    });
+    document.querySelectorAll('.nav-links a').forEach((item) => {
+      item.addEventListener('click', () => {
+        links.classList.remove('open');
+        user.classList.remove('open');
+      });
+    });
+    async function loadUser() {
+      try {
+        const res = await fetch('/.auth/me');
+        if (!res.ok) return;
+        const data = await res.json();
+        const principal = data.clientPrincipal;
+        if (!principal) return;
+        const name = principal.userDetails || 'User';
+        document.querySelector('.user-name').textContent = name;
+        const avatar = document.querySelector('.avatar');
+        avatar.src = `https://github.com/${name}.png`;
+        avatar.alt = name;
+      } catch {
+        /* ignore */
+      }
+    }
+    loadUser();
+  </script>
+</nav>
+<style>
+  .navbar {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background-color: var(--vanilla-cream);
+    padding: 0.5rem 0;
+  }
+  .navbar .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+  }
+  .nav-links a {
+    text-decoration: none;
+    color: var(--slate-river);
+    font-weight: 600;
+  }
+  .user-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+  .avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
+  .nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--slate-river);
+    font-size: 1.5rem;
+    cursor: pointer;
+  }
+  @media (max-width: 768px) {
+    .nav-links {
+      display: none;
+      flex-direction: column;
+      background-color: var(--vanilla-cream);
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      padding: 1rem;
+    }
+    .user-info {
+      display: none;
+      flex-direction: column;
+      background-color: var(--vanilla-cream);
+      position: absolute;
+      top: 100%;
+      right: 0;
+      padding: 1rem;
+      align-items: flex-start;
+    }
+    .nav-links.open {
+      display: flex;
+    }
+    .user-info.open {
+      display: flex;
+    }
+    .nav-toggle {
+      display: block;
+    }
+  }
+</style>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,0 +1,42 @@
+---
+import "../styles/global.css";
+import AdminNavbar from "../components/AdminNavbar.astro";
+import Favicon from '../images/favicon.svg';
+import Logo from '../images/alpakasoelde-logo.svg';
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href={Favicon.src} />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title} | Alpakasölde</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400&display=swap" rel="stylesheet" />
+    <meta name="description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />
+    <meta name="keywords" content="Alpakas, Alpakahof, Alpakawanderung, Frauenstein, Österreich, Tiererlebnisse" />
+    <meta name="author" content="Alpakasölde" />
+    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    <AdminNavbar />
+    <slot />
+  </body>
+</html>
+
+<style>
+  html,
+  body {
+    margin: 0;
+    width: 100%;
+  }
+</style>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../../layouts/Layout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 ---
 
-<Layout title="Admin Dashboard">
+<AdminLayout title="Admin Dashboard">
   <section class="admin-page section">
     <div class="container">
       <h2>Dashboard</h2>
@@ -15,7 +15,7 @@ import Layout from '../../layouts/Layout.astro';
       </ul>
     </div>
   </section>
-</Layout>
+</AdminLayout>
 
 <style>
   .admin-page {

--- a/src/pages/admin/messages.astro
+++ b/src/pages/admin/messages.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../../layouts/Layout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 ---
 
-<Layout title="Nachrichten">
+<AdminLayout title="Nachrichten">
   <section class="admin-page section">
     <div class="container">
       <h2>Eingegangene Nachrichten</h2>
@@ -25,7 +25,7 @@ import Layout from '../../layouts/Layout.astro';
       </div>
     </div>
   </section>
-</Layout>
+</AdminLayout>
 
 <script>
   async function loadMessages() {


### PR DESCRIPTION
## Summary
- implement new `AdminNavbar` with user avatar and name
- add `AdminLayout` that uses the new navigation
- switch admin pages to `AdminLayout`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841e03822888327b3f7218dbbd6af8c