### PR TITLE
Update admin navbar

### DIFF
--- a/src/components/AdminNavbar.astro
+++ b/src/components/AdminNavbar.astro
@@ -1,14 +1,22 @@
 ---
+import { Image } from "astro:assets";
+import Logo from "../images/alpakasoelde-logo.svg";
 ---
 <nav class="navbar">
   <div class="container">
+    <a href="/" class="logo">
+      <Image style="width:60px;height:60px" src={Logo} alt="Alpakasölde Logo" />
+    </a>
     <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
-    <ul class="nav-links">
-      <li><a href="/admin/messages">Messages</a></li>
-    </ul>
-    <div class="user-info">
-      <span class="user-name"></span>
-      <img class="avatar" alt="" />
+    <div class="nav-right">
+      <ul class="nav-links">
+        <li><a href="/admin">Dashboard</a></li>
+        <li><a href="/admin/messages">Messages</a></li>
+      </ul>
+      <div class="user-info">
+        <span class="user-name"></span>
+        <img class="avatar" alt="" />
+      </div>
     </div>
   </div>
   <script>
@@ -55,7 +63,12 @@
   .navbar .container {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+  }
+  .nav-right {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    gap: 1rem;
   }
   .nav-links {
     list-style: none;


### PR DESCRIPTION
## Summary
- add logo and dashboard link to the admin navbar
- align links to the right like in the default navbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684281172db08327b803047ad0c913e9