### PR TITLE
Sort messages descending

### DIFF
--- a/Api/GetMessagesFunction.cs
+++ b/Api/GetMessagesFunction.cs
@@ -20,6 +20,7 @@ public class GetMessagesFunction(ILoggerFactory loggerFactory)
 
         var messages = tableClient
             .Query<MessageEntity>()
+            .OrderByDescending(m => m.Timestamp)
             .Select(m => new
             {
                 m.Name,


### PR DESCRIPTION
## Summary
- order returned messages in descending timestamp order in `get-messages` API

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d5bb52dc8327b2135895f58261c6