### PR TITLE
Add old message count API and dashboard display

### DIFF
--- a/Api/GetOldMessageCountFunction.cs
+++ b/Api/GetOldMessageCountFunction.cs
@@ -1,0 +1,27 @@
+using Azure.Data.Tables;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+
+namespace Api;
+
+public class GetOldMessageCountFunction(ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<GetOldMessageCountFunction>();
+
+    [Function("get-old-message-count")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+    {
+        string? connectionString = Environment.GetEnvironmentVariable("MessageStorageConnection");
+        TableClient tableClient = new(connectionString, "messages");
+
+        DateTimeOffset threshold = DateTimeOffset.UtcNow.AddMonths(-6);
+        int count = tableClient.Query<MessageEntity>(m => m.Timestamp < threshold).Count();
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new { Count = count }).ConfigureAwait(false);
+        return response;
+    }
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -10,6 +10,7 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
         <img id="avatar" class="avatar" alt="" />
         <p id="greeting" class="greeting"></p>
       </div>
+      <p id="old-message-count" class="old-count"></p>
       <ul class="admin-links">
         <li><a class="btn" href="/admin/messages">Nachrichten</a></li>
       </ul>
@@ -43,6 +44,11 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
     font-weight: bold;
   }
 
+  .old-count {
+    margin-bottom: 1rem;
+    font-weight: 600;
+  }
+
   .admin-links {
     list-style: none;
     padding: 0;
@@ -71,5 +77,18 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
       /* ignore */
     }
   }
+
+  async function loadOldMessageCount() {
+    try {
+      const res = await fetch('/api/get-old-message-count');
+      if (!res.ok) return;
+      const data = await res.json();
+      document.getElementById('old-message-count').textContent =
+        `Nachrichten älter als 6 Monate: ${data.Count}`;
+    } catch {
+      /* ignore */
+    }
+  }
   loadUser();
+  loadOldMessageCount();
 </script>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -10,14 +10,18 @@
       "allowedRoles": ["admin"]
     },
     {
-      "route": "/api/get-messages",
-      "allowedRoles": ["admin"]
-    },
-    {
-      "route": "/*",
-      "serve": "/index.html",
-      "statusCode": 200,
-      "allowedRoles": ["anonymous", "authenticated"]
+        "route": "/api/get-messages",
+        "allowedRoles": ["admin"]
+      },
+      {
+        "route": "/api/get-old-message-count",
+        "allowedRoles": ["admin"]
+      },
+      {
+        "route": "/*",
+        "serve": "/index.html",
+        "statusCode": 200,
+        "allowedRoles": ["anonymous", "authenticated"]
     }
   ],
   "responseOverrides": {


### PR DESCRIPTION
## Summary
- add `get-old-message-count` Azure Function
- show archived message count on admin dashboard
- secure the new endpoint in `staticwebapp.config.json`

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build Api/Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ea72caac832795db530298eae194