### PR TITLE
Adjust hero logo size responsively

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -27,6 +27,13 @@ import Logo from "../images/AS_Gesammt_untereinander_Schwarz.svg";
     margin-bottom: 1.5rem;
   }
 
+  @media (min-width: 768px) {
+    .hero img {
+      width: 35rem;
+      height: 15rem;
+    }
+  }
+
   .sr-only {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## Summary
- enlarge hero logo for desktop
- keep smaller logo size on mobile screens

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ee32e40883279b3e15f552f7a172