### PR TITLE
Rename admin area to dashboard

### DIFF
--- a/Api/GetMessagesFunction.cs
+++ b/Api/GetMessagesFunction.cs
@@ -13,7 +13,7 @@ public class GetMessagesFunction(ILoggerFactory loggerFactory)
 
     [Function("get-messages")]
     public async Task<HttpResponseData> Run(
-        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "dashboard/get-messages")] HttpRequestData req)
     {
         string? connectionString = Environment.GetEnvironmentVariable("MessageStorageConnection");
         TableClient tableClient = new(connectionString, "messages");

--- a/Api/GetOldMessageCountFunction.cs
+++ b/Api/GetOldMessageCountFunction.cs
@@ -12,7 +12,7 @@ public class GetOldMessageCountFunction(ILoggerFactory loggerFactory)
 
     [Function("get-old-message-count")]
     public async Task<HttpResponseData> Run(
-        [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "dashboard/get-old-message-count")] HttpRequestData req)
     {
         string? connectionString = Environment.GetEnvironmentVariable("MessageStorageConnection");
         TableClient tableClient = new(connectionString, "messages");

--- a/Api/requests.http
+++ b/Api/requests.http
@@ -11,4 +11,4 @@ name=TestName&email=test@example.com&message=Hello from .http file
 
 ###
 
-GET {{base}}/api/get-messages
+GET {{base}}/api/dashboard/get-messages

--- a/src/components/DashboardNavbar.astro
+++ b/src/components/DashboardNavbar.astro
@@ -5,14 +5,14 @@ import Logo from "../images/AS_Symbolik_Backstein.svg";
 
 <nav class="navbar">
   <div class="container">
-    <a href="/admin" class="logo">
+    <a href="/dashboard" class="logo">
       <Image style="width:60px;height:60px" src={Logo} alt="Alpakasölde Logo" />
     </a>
     <a href="/" class="app-link">Zur App</a>
     <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
     <div class="nav-right">
       <ul class="nav-links">
-        <li><a href="/admin/messages">Messages</a></li>
+        <li><a href="/dashboard/messages">Messages</a></li>
       </ul>
       <div class="user-info">
         <span class="user-name"></span>

--- a/src/layouts/DashboardLayout.astro
+++ b/src/layouts/DashboardLayout.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/global.css";
-import AdminNavbar from "../components/AdminNavbar.astro";
+import DashboardNavbar from "../components/DashboardNavbar.astro";
 import Favicon from '../images/favicon.svg';
 
 interface Props {
@@ -27,7 +27,7 @@ const { title } = Astro.props;
     <meta name="robots" content="noindex" />
   </head>
   <body>
-    <AdminNavbar />
+    <DashboardNavbar />
     <slot />
   </body>
 </html>

--- a/src/pages/403.astro
+++ b/src/pages/403.astro
@@ -8,7 +8,7 @@ import JohannNeugierig from '../images/alpakas/johann_neugierig.png';
   <section class="service-page section">
     <div class="container">
       <h2>403 Kein Zutritt</h2>
-      <p class="alpaca-highlight">Hier kommen nur Admin-Alpakas vorbei. Du scheinst keines zu sein!</p>
+      <p class="alpaca-highlight">Hier kommen nur Dashboard-Alpakas vorbei. Du scheinst keines zu sein!</p>
       <Image src={JohannNeugierig} alt="Ueberraschte Alpaka" class="alpaca-img" />
       <p style="text-align:center;margin-top:2rem;">
         <a href="/" class="btn">Zur&uuml;ck zur Startseite</a>

--- a/src/pages/dashboard/index.astro
+++ b/src/pages/dashboard/index.astro
@@ -1,9 +1,9 @@
 ---
-import AdminLayout from '../../layouts/AdminLayout.astro';
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
 ---
 
-<AdminLayout title="Admin Dashboard">
-  <section class="admin-page section">
+<DashboardLayout title="Dashboard">
+  <section class="dashboard-page section">
     <div class="container">
       <h2>Dashboard</h2>
       <div class="user-info">
@@ -11,15 +11,15 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
         <p id="greeting" class="greeting"></p>
       </div>
       <p id="old-message-count" class="old-count"></p>
-      <ul class="admin-links">
-        <li><a class="btn" href="/admin/messages">Nachrichten</a></li>
+      <ul class="dashboard-links">
+        <li><a class="btn" href="/dashboard/messages">Nachrichten</a></li>
       </ul>
     </div>
   </section>
-</AdminLayout>
+</DashboardLayout>
 
 <style>
-  .admin-page {
+  .dashboard-page {
     background-color: var(--auwasser);
     color: var(--taubenblau);
     text-align: center;
@@ -49,12 +49,12 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
     font-weight: 600;
   }
 
-  .admin-links {
+  .dashboard-links {
     list-style: none;
     padding: 0;
   }
 
-  .admin-links li {
+  .dashboard-links li {
     margin-bottom: 1rem;
   }
 </style>
@@ -80,7 +80,7 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
 
   async function loadOldMessageCount() {
     try {
-      const res = await fetch('/api/get-old-message-count');
+      const res = await fetch('/api/dashboard/get-old-message-count');
       if (!res.ok) return;
       const data = await res.json();
       document.getElementById('old-message-count').textContent =

--- a/src/pages/dashboard/messages.astro
+++ b/src/pages/dashboard/messages.astro
@@ -1,9 +1,9 @@
 ---
-import AdminLayout from '../../layouts/AdminLayout.astro';
+import DashboardLayout from '../../layouts/DashboardLayout.astro';
 ---
 
-<AdminLayout title="Nachrichten">
-  <section class="admin-page section">
+<DashboardLayout title="Nachrichten">
+  <section class="dashboard-page section">
     <div class="container">
       <h2>Eingegangene Nachrichten</h2>
       <div class="table-wrapper">
@@ -25,12 +25,12 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
       </div>
     </div>
   </section>
-</AdminLayout>
+</DashboardLayout>
 
 <script>
   async function loadMessages() {
     try {
-      const res = await fetch('/api/get-messages');
+      const res = await fetch('/api/dashboard/get-messages');
       if (!res.ok) return;
       const msgs = await res.json();
       const tbody = document.getElementById('message-table-body');
@@ -51,7 +51,7 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
 </script>
 
 <style>
-  .admin-page {
+  .dashboard-page {
     background-color: var(--auwasser);
     color: var(--taubenblau);
   }

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -6,15 +6,15 @@
   },
   "routes": [
     {
-      "route": "/admin/*",
+      "route": "/dashboard/*",
       "allowedRoles": ["admin"]
     },
     {
-        "route": "/api/get-messages",
+        "route": "/api/dashboard/get-messages",
         "allowedRoles": ["admin"]
       },
       {
-        "route": "/api/get-old-message-count",
+        "route": "/api/dashboard/get-old-message-count",
         "allowedRoles": ["admin"]
       },
       {


### PR DESCRIPTION
## Summary
- rename Admin pages, layout and navbar to Dashboard
- adjust API routes to include `/dashboard`
- update access control configuration
- tweak references and text for Dashboard naming

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build Api/Api.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843c3156bfc83279e7099c59a0a5727