### PR TITLE
Increase hero logo size on mobile

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -22,8 +22,8 @@ import Logo from "../images/AS_Gesammt_untereinander_Schwarz.svg";
   }
 
   .hero img {
-    width: 14rem;
-    height: 14rem;
+    width: 16rem;
+    height: 10rem;
     margin-bottom: 1.5rem;
   }
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -22,8 +22,8 @@ import Logo from "../images/AS_Gesammt_untereinander_Schwarz.svg";
   }
 
   .hero img {
-    width: 12rem;
-    height: 12rem;
+    width: 14rem;
+    height: 14rem;
     margin-bottom: 1.5rem;
   }
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -22,8 +22,8 @@ import Logo from "../images/AS_Gesammt_untereinander_Schwarz.svg";
   }
 
   .hero img {
-    width: 10rem;
-    height: 10rem;
+    width: 12rem;
+    height: 12rem;
     margin-bottom: 1.5rem;
   }
 


### PR DESCRIPTION
## Summary
- make the hero logo a bit larger on small screens

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6843c6f9d0cc832792eafa3d53f37f14