### PR TITLE
Fix dashboard order

### DIFF
--- a/src/pages/dashboard/index.astro
+++ b/src/pages/dashboard/index.astro
@@ -8,11 +8,8 @@ import DashboardAlpakas from '../../components/DashboardAlpakas.astro';
   <section class="dashboard-page section">
     <div class="container">
       <h2>Dashboard</h2>
-      <Stats />
-      <ul class="dashboard-links">
-        <li><a class="btn" href="/dashboard/messages">Nachrichten</a></li>
-      </ul>
       <DashboardAlpakas />
+      <Stats />
     </div>
   </section>
 </DashboardLayout>
@@ -25,14 +22,5 @@ import DashboardAlpakas from '../../components/DashboardAlpakas.astro';
   }
 
   /* stats styles are defined in component */
-
-  .dashboard-links {
-    list-style: none;
-    padding: 0;
-  }
-
-  .dashboard-links li {
-    margin-bottom: 1rem;
-  }
 </style>
 


### PR DESCRIPTION
## Summary
- remove link to dashboard messages
- show DashboardAlpakas before Stats component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6843fa0fe6e88327bf6b4fd1a3624767