### PR TITLE
Hide Alpaka form initially

### DIFF
--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -19,7 +19,7 @@
   const toggle = document.getElementById('add-alpaka-toggle');
   const form = document.getElementById('add-alpaka-form');
   toggle.addEventListener('click', () => {
-    form.hidden = !form.hidden;
+    form.hidden = false;
   });
 
   async function loadAlpakas() {


### PR DESCRIPTION
## Summary
- make Alpaka form start hidden and show it on '+' click

## Testing
- `npx --no-install astro build`

------
https://chatgpt.com/codex/tasks/task_b_68440d882cd88327b8dc03163a0ff7d8