### PR TITLE
Update dashboard section colors

### DIFF
--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -1,19 +1,23 @@
-<div class="alpaka-header">
-  <h2>Alpakas</h2>
-  <button id="add-alpaka-toggle" class="add-btn" aria-label="Neues Alpaka hinzufügen">+</button>
-</div>
-<ul id="alpaka-list" class="alpaka-list"></ul>
-<form id="add-alpaka-form" class="alpaka-form" method="post" action="/api/alpakas" hidden>
-  <div class="form-field">
-    <label for="alpaka-name">Name*</label>
-    <input id="alpaka-name" name="name" type="text" required />
+<section class="dashboard-alpaka section">
+  <div class="container">
+    <div class="alpaka-header">
+      <h2>Alpakas</h2>
+      <button id="add-alpaka-toggle" class="add-btn" aria-label="Neues Alpaka hinzufügen">+</button>
+    </div>
+    <ul id="alpaka-list" class="alpaka-list"></ul>
+    <form id="add-alpaka-form" class="alpaka-form" method="post" action="/api/alpakas" hidden>
+      <div class="form-field">
+        <label for="alpaka-name">Name*</label>
+        <input id="alpaka-name" name="name" type="text" required />
+      </div>
+      <div class="form-field">
+        <label for="alpaka-geburtsdatum">Geburtsdatum*</label>
+        <input id="alpaka-geburtsdatum" name="geburtsdatum" type="date" required />
+      </div>
+      <button type="submit" class="btn">Neues Alpaka anlegen</button>
+    </form>
   </div>
-  <div class="form-field">
-    <label for="alpaka-geburtsdatum">Geburtsdatum*</label>
-    <input id="alpaka-geburtsdatum" name="geburtsdatum" type="date" required />
-  </div>
-  <button type="submit" class="btn">Neues Alpaka anlegen</button>
-</form>
+</section>
 
 <script>
   const toggle = document.getElementById('add-alpaka-toggle');
@@ -56,6 +60,11 @@
 </script>
 
 <style>
+  .dashboard-alpaka {
+    background-color: var(--himmelblau);
+    color: var(--schurwolle);
+    text-align: center;
+  }
   .alpaka-header {
     display: flex;
     align-items: center;

--- a/src/components/dashboard/Stats.astro
+++ b/src/components/dashboard/Stats.astro
@@ -1,6 +1,10 @@
-<div class="stats-card">
-  <p id="old-message-count" class="old-count loading">Lade Daten...</p>
-</div>
+<section class="dashboard-stats section">
+  <div class="container">
+    <div class="stats-card">
+      <p id="old-message-count" class="old-count loading">Lade Daten...</p>
+    </div>
+  </div>
+</section>
 
 <script>
   async function loadOldMessageCount() {
@@ -19,6 +23,11 @@
 </script>
 
 <style>
+  .dashboard-stats {
+    background-color: var(--weidegruen);
+    color: var(--schurwolle);
+    text-align: center;
+  }
   .stats-card {
     display: flex;
     justify-content: center;

--- a/src/pages/dashboard/index.astro
+++ b/src/pages/dashboard/index.astro
@@ -5,22 +5,7 @@ import Alpakas from '../../components/dashboard/Alpakas.astro';
 ---
 
 <DashboardLayout title="Dashboard">
-  <section class="dashboard-page section">
-    <div class="container">
-      <h2>Dashboard</h2>
-      <Alpakas />
-      <Stats />
-    </div>
-  </section>
+  <Alpakas />
+  <Stats />
 </DashboardLayout>
-
-<style>
-  .dashboard-page {
-    background-color: var(--auwasser);
-    color: var(--taubenblau);
-    text-align: center;
-  }
-
-  /* stats styles are defined in component */
-</style>
 


### PR DESCRIPTION
## Summary
- wrap dashboard alpaka and stats sections in their own section elements
- add background colors to each dashboard component
- simplify dashboard index page layout

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build Api/Api.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844161744fc8327a5f1f2291b4068e0