### PR TITLE
Add alpaca submission function

### DIFF
--- a/Api/AddAlpakaFunction.cs
+++ b/Api/AddAlpakaFunction.cs
@@ -1,0 +1,76 @@
+using Azure.Data.Tables;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Web;
+
+namespace Api;
+
+public class AddAlpakaFunction(ILoggerFactory loggerFactory)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<AddAlpakaFunction>();
+
+    private const int NameMaxLength = 100;
+
+    [Function("add-alpaka")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "dashboard/alpakas")] HttpRequestData req)
+    {
+        string? body = await new StreamReader(req.Body).ReadToEndAsync().ConfigureAwait(false);
+
+        _logger.LogInformation("Received alpaka data: {Body}", body);
+
+        var parsedForm = HttpUtility.ParseQueryString(body);
+        string? name = parsedForm["name"]?.Trim();
+        string? geburtsdatum = parsedForm["geburtsdatum"]?.Trim();
+        _logger.LogInformation("Parsed form data - Name: '{Name}', Geburtsdatum: '{Geburtsdatum}'", name, geburtsdatum);
+
+        var missingFields = new[]
+            {
+                (Value: name, FieldName: "Name"),
+                (Value: geburtsdatum, FieldName: "Geburtsdatum")
+            }
+            .Where(x => string.IsNullOrWhiteSpace(x.Value))
+            .Select(x => x.FieldName)
+            .ToList();
+        if (missingFields.Count > 0)
+        {
+            var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await badRequestResponse.WriteAsJsonAsync(new
+            {
+                title = "Bad Request",
+                status = (int)HttpStatusCode.BadRequest,
+                detail = $"{string.Join(", ", missingFields)} are required fields and must be provided."
+            }).ConfigureAwait(false);
+            return badRequestResponse;
+        }
+
+        if (name!.Length > NameMaxLength)
+        {
+            var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await badRequestResponse.WriteAsJsonAsync(new
+            {
+                title = "Bad Request",
+                status = (int)HttpStatusCode.BadRequest,
+                detail = $"Name exceeds {NameMaxLength} characters."
+            }).ConfigureAwait(false);
+            return badRequestResponse;
+        }
+
+        AlpakaEntity entity = new()
+        {
+            Name = name!,
+            Geburtsdatum = geburtsdatum!
+        };
+
+        string? connectionString = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageConnection);
+        TableClient tableClient = new(connectionString, "alpakas");
+        await tableClient.AddEntityAsync(entity).ConfigureAwait(false);
+
+        var response = req.CreateResponse(HttpStatusCode.SeeOther);
+        response.Headers.Add("Location", "/dashboard");
+
+        return response;
+    }
+}

--- a/Api/AlpakaEntity.cs
+++ b/Api/AlpakaEntity.cs
@@ -1,0 +1,15 @@
+namespace Api;
+
+using Azure;
+using Azure.Data.Tables;
+
+public sealed class AlpakaEntity : ITableEntity
+{
+    public required string Name { get; set; }
+    public required string Geburtsdatum { get; set; }
+
+    public DateTimeOffset? Timestamp { get; set; }
+    public ETag ETag { get; set; }
+    public string PartitionKey { get; set; } = "AlpakaPartition";
+    public string RowKey { get; set; } = Guid.NewGuid().ToString();
+}

--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -19,7 +19,7 @@
   <div id="alpaka-lightbox" class="lightbox" hidden>
     <div class="lightbox-content">
       <button type="button" id="close-alpaka-form" class="close-btn" aria-label="Schließen">×</button>
-      <form id="add-alpaka-form" class="alpaka-form" method="post" action="/api/alpakas">
+      <form id="add-alpaka-form" class="alpaka-form" method="post" action="/api/dashboard/alpakas">
         <div class="form-field">
           <label for="alpaka-name">Name*</label>
           <input id="alpaka-name" name="name" type="text" maxlength="100" required />

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -9,8 +9,12 @@
       "route": "/dashboard/*",
       "allowedRoles": ["admin"]
     },
-    {
+      {
         "route": "/api/dashboard/messages",
+        "allowedRoles": ["admin"]
+      },
+      {
+        "route": "/api/dashboard/alpakas",
         "allowedRoles": ["admin"]
       },
       {


### PR DESCRIPTION
## Summary
- create an Azure Function to store alpaca data in Table Storage
- restrict new API route in `staticwebapp.config.json`
- update dashboard alpaca form to post to new function

## Testing
- `dotnet build Api/Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844201a94048327986e82c838d2093e