### PR TITLE
Add alpaka name placeholders

### DIFF
--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -91,8 +91,11 @@
         const row = document.createElement('tr');
         row.className = 'alpaka-item';
         const age = calculateAge(alpaca.Geburtsdatum);
+        const avatar = alpaca.ImageUrl
+          ? `<img class="profile-photo" src="${alpaca.ImageUrl}" alt="${alpaca.Name}" />`
+          : `<div class="profile-placeholder">${alpaca.Name.charAt(0).toUpperCase()}</div>`;
         row.innerHTML = `
-          <td><img class="profile-photo" src="${alpaca.ImageUrl}" alt="${alpaca.Name}" /></td>
+          <td>${avatar}</td>
           <td class="alpaka-name">${alpaca.Name}</td>
           <td class="alpaka-age">${age}</td>`;
         list.appendChild(row);
@@ -177,6 +180,17 @@
     height: 2.5rem;
     border-radius: 50%;
     object-fit: cover;
+  }
+  .profile-placeholder {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--himmelblau);
+    color: var(--schurwolle);
+    font-weight: 600;
   }
   .lightbox {
     position: fixed;


### PR DESCRIPTION
## Summary
- show alpaka avatar placeholders when no image is available
- style placeholders with a blue background and initials

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_68444d786c008327ae37a7b1c4d15143