### PR TITLE
Refactor SEO into Head component

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,55 @@
+---
+import Favicon from "../images/favicon.svg";
+import Logo from "../images/AS_Symbolik_Schwarz.svg";
+
+interface Props {
+  title?: string;
+  robots?: string;
+}
+
+const { title = "Alpakas\u00f6lde", robots = "index, follow" } = Astro.props;
+---
+<link rel="icon" type="image/svg+xml" href={Favicon.src} />
+<meta name="generator" content={Astro.generator} />
+<title>{title} | Alpakas\u00f6lde</title>
+
+<!-- SEO Meta Tags -->
+<meta name="description" content="Kleiner Alpakahof in Frauenstein, Ober\u00f6sterreich. Alpakaerlebnisse und Wanderungen." />
+<meta name="keywords" content="Alpakas, Alpakahof, Alpakawanderung, Frauenstein, \u00d6sterreich, Tiererlebnisse" />
+<meta name="author" content="Alpakas\u00f6lde" />
+<link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
+<meta name="robots" content={robots} />
+
+<!-- Open Graph / Social Media -->
+<meta property="og:type" content="website" />
+<meta property="og:title" content={`${title} | Alpakas\u00f6lde`} />
+<meta property="og:description" content="Kleiner Alpakahof in Frauenstein, Ober\u00f6sterreich. Alpakaerlebnisse und Wanderungen." />
+<meta property="og:site_name" content="Alpakas\u00f6lde" />
+<meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).toString()} />
+<meta property="og:image" content={new URL(Logo.src, Astro.site).toString()} />
+
+<!-- Twitter Cards -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={`${title} | Alpakas\u00f6lde`} />
+<meta name="twitter:description" content="Kleiner Alpakahof in Frauenstein, Ober\u00f6sterreich. Alpakaerlebnisse und Wanderungen." />
+<meta name="twitter:image" content={new URL(Logo.src, Astro.site).toString()} />
+
+<!-- Structured Data -->
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Alpakas\u00f6lde",
+    "description": "Kleiner Alpakahof in Frauenstein, Ober\u00f6sterreich",
+    "image": Favicon.src,
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "AT",
+      "addressRegion": "Ober\u00f6sterreich"
+    },
+    "areaServed": "Ober\u00f6sterreich",
+    "serviceType": ["Alpakawanderungen", "Tiererlebnisse"],
+    "priceRange": "\u20ac\u20ac"
+  }
+</script>
+

--- a/src/layouts/DashboardLayout.astro
+++ b/src/layouts/DashboardLayout.astro
@@ -1,7 +1,7 @@
 ---
 import "../styles/global.css";
 import DashboardNavbar from "../components/DashboardNavbar.astro";
-import Favicon from '../images/favicon.svg';
+import Head from '../components/Head.astro';
 
 interface Props {
   title: string;
@@ -14,17 +14,10 @@ const { title } = Astro.props;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href={Favicon.src} />
-    <meta name="generator" content={Astro.generator} />
-    <title>{title} | Alpakasölde</title>
+    <Head title={title} robots="noindex" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400&display=swap" rel="stylesheet" />
-    <meta name="description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />
-    <meta name="keywords" content="Alpakas, Alpakahof, Alpakawanderung, Frauenstein, Österreich, Tiererlebnisse" />
-    <meta name="author" content="Alpakasölde" />
-    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
-    <meta name="robots" content="noindex" />
   </head>
   <body>
     <DashboardNavbar />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,8 +2,7 @@
 import "../styles/global.css";
 import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
-import Favicon from '../images/favicon.svg';
-import Logo from '../images/AS_Symbolik_Schwarz.svg';
+import Head from '../components/Head.astro';
 import '@fontsource/bricolage-grotesque/300.css';
 import '@fontsource/bricolage-grotesque/400.css';
 
@@ -16,53 +15,11 @@ const { title } = Astro.props;
 
 <!doctype html>
 <html lang="de">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-                <link rel="icon" type="image/svg+xml" href={Favicon.src} />
-                <meta name="generator" content={Astro.generator} />
-                <title>{title} | Alpakasölde</title>
-		
-                <!-- SEO Meta Tags -->
-                <meta name="description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />
-                <meta name="keywords" content="Alpakas, Alpakahof, Alpakawanderung, Frauenstein, Österreich, Tiererlebnisse" />
-                <meta name="author" content="Alpakasölde" />
-                <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
-                <meta name="robots" content="index, follow" />
-		
-		<!-- Open Graph / Social Media -->
-                <meta property="og:type" content="website" />
-                <meta property="og:title" content={`${title} | Alpakasölde`} />
-                <meta property="og:description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />
-                <meta property="og:site_name" content="Alpakasölde" />
-                <meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).toString()} />
-                <meta property="og:image" content={new URL(Logo.src, Astro.site).toString()} />
-
-                <!-- Twitter Cards -->
-                <meta name="twitter:card" content="summary_large_image" />
-                <meta name="twitter:title" content={`${title} | Alpakasölde`} />
-                <meta name="twitter:description" content="Kleiner Alpakahof in Frauenstein, Oberösterreich. Alpakaerlebnisse und Wanderungen." />
-                <meta name="twitter:image" content={new URL(Logo.src, Astro.site).toString()} />
-		
-		<!-- Structured Data -->
-                <script type="application/ld+json">
-                        {
-                                "@context": "https://schema.org",
-                                "@type": "LocalBusiness",
-                                "name": "Alpakasölde",
-                                "description": "Kleiner Alpakahof in Frauenstein, Oberösterreich",
-                                "image": Favicon.src,
-                                "address": {
-                                        "@type": "PostalAddress",
-                                        "addressCountry": "AT",
-                                        "addressRegion": "Oberösterreich"
-                                },
-                                "areaServed": "Oberösterreich",
-                                "serviceType": ["Alpakawanderungen", "Tiererlebnisse"],
-                                "priceRange": "€€"
-                        }
-		</script>
-	</head>
+       <head>
+               <meta charset="UTF-8" />
+               <meta name="viewport" content="width=device-width" />
+               <Head title={title} />
+       </head>
         <body>
                 <Navbar />
                 <slot />


### PR DESCRIPTION
## Summary
- create `Head` component for SEO metadata
- use `Head` in `Layout` and `DashboardLayout`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844562c82048327abd0d0b42a2ce794