### PR TITLE
Enable TypeScript in client scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -52,12 +52,12 @@
 
     </aside>
   </div>
-  <script>
-    const form = document.getElementById('contact-form');
-    const limits = { name: 100, email: 254, message: 2000 };
+  <script lang="ts">
+    const form = document.getElementById('contact-form') as HTMLFormElement;
+    const limits: Record<string, number> = { name: 100, email: 254, message: 2000 };
 
     Object.entries(limits).forEach(([id, max]) => {
-      const el = document.getElementById(id);
+      const el = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement;
       el.addEventListener('input', () => {
         if (el.value.length > max) {
           el.setCustomValidity(`Maximal ${max} Zeichen erlaubt`);
@@ -67,11 +67,11 @@
       });
     });
 
-    const submitButton = form.querySelector('button[type="submit"]');
+    const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
 
     form.addEventListener('submit', (e) => {
       for (const [id, max] of Object.entries(limits)) {
-        const el = document.getElementById(id);
+        const el = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement;
         if (el.value.trim().length > max) {
           el.setCustomValidity(`Maximal ${max} Zeichen erlaubt`);
           el.reportValidity();

--- a/src/components/DashboardNavbar.astro
+++ b/src/components/DashboardNavbar.astro
@@ -18,27 +18,34 @@ import Logo from "../images/AS_Symbolik_Backstein.svg";
     </ul>
     <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
   </div>
-  <script>
-    const toggle = document.querySelector('.nav-toggle');
-    const links = document.querySelector('.nav-links');
+  <script lang="ts">
+    const toggle = document.querySelector<HTMLButtonElement>('.nav-toggle')!;
+    const links = document.querySelector<HTMLUListElement>('.nav-links')!;
     toggle.addEventListener('click', () => {
       links.classList.toggle('open');
     });
-    document.querySelectorAll('.nav-links a').forEach((item) => {
+    document.querySelectorAll<HTMLAnchorElement>('.nav-links a').forEach((item) => {
       item.addEventListener('click', () => {
         links.classList.remove('open');
       });
     });
-    async function loadUser() {
+
+    interface AuthResponse {
+      clientPrincipal?: {
+        userDetails?: string;
+      };
+    }
+
+    async function loadUser(): Promise<void> {
       try {
         const res = await fetch('/.auth/me');
         if (!res.ok) return;
-        const data = await res.json();
+        const data: AuthResponse = await res.json();
         const principal = data.clientPrincipal;
         if (!principal) return;
         const name = principal.userDetails || 'User';
-        document.querySelector('.user-name').textContent = name;
-        const avatar = document.querySelector('.avatar');
+        document.querySelector('.user-name')!.textContent = name;
+        const avatar = document.querySelector<HTMLImageElement>('.avatar')!;
         avatar.src = `https://github.com/${name}.png`;
         avatar.alt = name;
       } catch {

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -15,10 +15,10 @@ import Logo from "../images/AS_Symbolik_Schwarz.svg";
       <li><a href="/#kontakt">Kontakt</a></li>
     </ul>
   </div>
-  <script>
-    const toggle = document.querySelector('.nav-toggle');
-    const links = document.querySelector('.nav-links');
-    const linkItems = document.querySelectorAll('.nav-links a');
+  <script lang="ts">
+    const toggle = document.querySelector<HTMLButtonElement>('.nav-toggle')!;
+    const links = document.querySelector<HTMLUListElement>('.nav-links')!;
+    const linkItems = document.querySelectorAll<HTMLAnchorElement>('.nav-links a');
     toggle.addEventListener('click', () => {
       links.classList.toggle('open');
     });

--- a/src/components/Slideshow.astro
+++ b/src/components/Slideshow.astro
@@ -1,8 +1,8 @@
 ---
-import { Image } from "astro:assets";
+import { Image, type ImageMetadata } from "astro:assets";
 
 interface Props {
-  images: any[];
+  images: ImageMetadata[];
 }
 
 const { images } = Astro.props as Props;
@@ -16,8 +16,10 @@ const { images } = Astro.props as Props;
   ))}
 </ul>
 
-<script>
-  const slides = Array.from(document.querySelectorAll('[image-slide]'));
+<script lang="ts">
+  const slides = Array.from(
+    document.querySelectorAll<HTMLLIElement>('[image-slide]')
+  );
   let index = 0;
   setInterval(() => {
     slides[index].classList.add('hidden');

--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -34,11 +34,11 @@
   </div>
 </section>
 
-<script>
-  const toggle = document.getElementById('add-alpaka-toggle');
-  const lightbox = document.getElementById('alpaka-lightbox');
-  const closeBtn = document.getElementById('close-alpaka-form');
-  const form = document.getElementById('add-alpaka-form');
+<script lang="ts">
+  const toggle = document.getElementById('add-alpaka-toggle') as HTMLButtonElement;
+  const lightbox = document.getElementById('alpaka-lightbox') as HTMLDivElement;
+  const closeBtn = document.getElementById('close-alpaka-form') as HTMLButtonElement;
+  const form = document.getElementById('add-alpaka-form') as HTMLFormElement;
 
   toggle.addEventListener('click', () => {
     lightbox.hidden = false;
@@ -48,14 +48,14 @@
     lightbox.hidden = true;
   });
 
-  lightbox.addEventListener('click', (e) => {
+  lightbox.addEventListener('click', (e: MouseEvent) => {
     if (e.target === lightbox) lightbox.hidden = true;
   });
 
-  const limits = { 'alpaka-name': 100 };
+  const limits: Record<string, number> = { 'alpaka-name': 100 };
 
   Object.entries(limits).forEach(([id, max]) => {
-    const el = document.getElementById(id);
+    const el = document.getElementById(id) as HTMLInputElement;
     el.addEventListener('input', () => {
       if (el.value.length > max) {
         el.setCustomValidity(`Maximal ${max} Zeichen erlaubt`);
@@ -65,11 +65,11 @@
     });
   });
 
-  const submitButton = form.querySelector('button[type="submit"]');
+  const submitButton = form.querySelector<HTMLButtonElement>('button[type="submit"]')!;
 
   form.addEventListener('submit', (e) => {
     for (const [id, max] of Object.entries(limits)) {
-      const el = document.getElementById(id);
+      const el = document.getElementById(id) as HTMLInputElement;
       if (el.value.trim().length > max) {
         el.setCustomValidity(`Maximal ${max} Zeichen erlaubt`);
         el.reportValidity();
@@ -81,12 +81,18 @@
     submitButton.classList.add('loading');
   });
 
-  async function loadAlpakas() {
+  interface Alpaca {
+    Name: string;
+    Geburtsdatum: string;
+    ImageUrl?: string;
+  }
+
+  async function loadAlpakas(): Promise<void> {
     try {
       const res = await fetch('/api/dashboard/alpakas');
       if (!res.ok) return;
-      const alpacas = await res.json();
-      const list = document.getElementById('alpaka-list');
+      const alpacas: Alpaca[] = await res.json();
+      const list = document.getElementById('alpaka-list') as HTMLTableSectionElement;
       alpacas.forEach((alpaca) => {
         const row = document.createElement('tr');
         row.className = 'alpaka-item';
@@ -105,7 +111,7 @@
     }
   }
 
-  function calculateAge(dateStr) {
+  function calculateAge(dateStr: string): string {
     const birth = new Date(dateStr);
     const now = new Date();
     let years = now.getFullYear() - birth.getFullYear();

--- a/src/components/dashboard/Stats.astro
+++ b/src/components/dashboard/Stats.astro
@@ -6,13 +6,17 @@
   </div>
 </section>
 
-<script>
-  async function loadOldMessageCount() {
+<script lang="ts">
+  interface OldCount {
+    Count: number;
+  }
+
+  async function loadOldMessageCount(): Promise<void> {
     try {
       const res = await fetch('/api/dashboard/messages/count-old');
       if (!res.ok) return;
-      const data = await res.json();
-      const el = document.getElementById('old-message-count');
+      const data: OldCount = await res.json();
+      const el = document.getElementById('old-message-count') as HTMLElement;
       el.textContent = `Nachrichten älter als 6 Monate: ${data.Count}`;
       el.classList.remove('loading');
     } catch {

--- a/src/layouts/DashboardLayout.astro
+++ b/src/layouts/DashboardLayout.astro
@@ -7,7 +7,7 @@ interface Props {
   title: string;
 }
 
-const { title } = Astro.props;
+const { title } = Astro.props as Props;
 ---
 <!doctype html>
 <html lang="de">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,10 +8,10 @@ import '@fontsource/bricolage-grotesque/300.css';
 import '@fontsource/bricolage-grotesque/400.css';
 
 interface Props {
-	title: string;
+        title: string;
 }
 
-const { title } = Astro.props;
+const { title } = Astro.props as Props;
 ---
 
 <!doctype html>

--- a/src/pages/dashboard/messages.astro
+++ b/src/pages/dashboard/messages.astro
@@ -27,13 +27,20 @@ import DashboardLayout from '../../layouts/DashboardLayout.astro';
   </section>
 </DashboardLayout>
 
-<script>
-  async function loadMessages() {
+<script lang="ts">
+  interface Message {
+    Name: string;
+    Email: string;
+    Message: string;
+    Timestamp: string;
+  }
+
+  async function loadMessages(): Promise<void> {
     try {
       const res = await fetch('/api/dashboard/messages');
       if (!res.ok) return;
-      const msgs = await res.json();
-      const tbody = document.getElementById('message-table-body');
+      const msgs: Message[] = await res.json();
+      const tbody = document.getElementById('message-table-body') as HTMLTableSectionElement;
       tbody.innerHTML = '';
       msgs.forEach((msg) => {
         const tr = document.createElement('tr');


### PR DESCRIPTION
## Summary
- convert all client `<script>` blocks to `lang="ts"`
- add missing prop typing in layouts
- type slideshow image props
- add `astro check` to `npm run build`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_684456eb9c948327ad38841ffb5698c6