### PR TITLE
Add alpaca detail page

### DIFF
--- a/Api/GetAlpakaFunction.cs
+++ b/Api/GetAlpakaFunction.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.Data.Tables;
 using Azure.Storage;
 using Azure.Storage.Blobs;
@@ -6,7 +7,6 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using System.Net;
-using System.IO;
 
 namespace Api;
 

--- a/Api/GetAlpakaFunction.cs
+++ b/Api/GetAlpakaFunction.cs
@@ -1,0 +1,80 @@
+using Azure.Data.Tables;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.IO;
+
+namespace Api;
+
+public class GetAlpakaFunction(
+    ILoggerFactory loggerFactory,
+    TableServiceClient tableServiceClient,
+    BlobServiceClient blobServiceClient)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<GetAlpakaFunction>();
+    private readonly TableServiceClient _tableServiceClient = tableServiceClient;
+    private readonly BlobServiceClient _blobServiceClient = blobServiceClient;
+
+    [Function("get-alpaka")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "dashboard/alpakas/{id}")] HttpRequestData req,
+        string id)
+    {
+        TableClient tableClient = _tableServiceClient.GetTableClient("alpakas");
+        BlobContainerClient container = _blobServiceClient.GetBlobContainerClient("alpakas");
+
+        try
+        {
+            Response<AlpakaEntity> result = await tableClient.GetEntityAsync<AlpakaEntity>("AlpakaPartition", id).ConfigureAwait(false);
+            AlpakaEntity alpaka = result.Value;
+
+            string? sasUrl = null;
+            if (!string.IsNullOrWhiteSpace(alpaka.ImageUrl))
+            {
+                string blobName = Path.GetFileName(new Uri(alpaka.ImageUrl).AbsolutePath);
+                BlobClient blob = container.GetBlobClient(blobName);
+
+                var expiresOn = DateTimeOffset.UtcNow.AddMinutes(30);
+                var sasBuilder = new BlobSasBuilder
+                {
+                    BlobContainerName = container.Name,
+                    BlobName = blobName,
+                    Resource = "b",
+                    ExpiresOn = expiresOn
+                };
+                sasBuilder.SetPermissions(BlobSasPermissions.Read);
+
+                var storageAccountName = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountName)
+                    ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_NAME' is not set.");
+                var storageAccountKey = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountKey)
+                    ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_KEY' is not set.");
+                StorageSharedKeyCredential credential = new(
+                    storageAccountName,
+                    storageAccountKey
+                );
+                var sasToken = sasBuilder.ToSasQueryParameters(credential).ToString();
+                sasUrl = $"{blob.Uri}?{sasToken}";
+            }
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(new
+            {
+                Id = alpaka.RowKey,
+                alpaka.Name,
+                alpaka.Geburtsdatum,
+                ImageUrl = sasUrl
+            }).ConfigureAwait(false);
+            return response;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            var response = req.CreateResponse(HttpStatusCode.NotFound);
+            await response.WriteAsJsonAsync(new { detail = "Not Found" }).ConfigureAwait(false);
+            return response;
+        }
+    }
+}

--- a/Api/GetAlpakasFunction.cs
+++ b/Api/GetAlpakasFunction.cs
@@ -1,7 +1,6 @@
 using Azure.Data.Tables;
 using Azure.Storage;
 using Azure.Storage.Blobs;
-using Azure.Storage.Sas;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -26,38 +25,17 @@ public class GetAlpakasFunction(
         TableClient tableClient = _tableServiceClient.GetTableClient("alpakas");
         BlobContainerClient container = _blobServiceClient.GetBlobContainerClient("alpakas");
 
+        var storageAccountName = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountName)
+            ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_NAME' is not set.");
+        var storageAccountKey = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountKey)
+            ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_KEY' is not set.");
+
         var alpakas = tableClient
             .Query<AlpakaEntity>()
             .OrderBy(a => a.Name)
             .Select(a =>
             {
-                string? sasUrl = null;
-                if (!string.IsNullOrWhiteSpace(a.ImageUrl))
-                {
-                    string blobName = Path.GetFileName(new Uri(a.ImageUrl).AbsolutePath);
-                    BlobClient blob = container.GetBlobClient(blobName);
-
-                    var expiresOn = DateTimeOffset.UtcNow.AddMinutes(30);
-                    var sasBuilder = new BlobSasBuilder
-                    {
-                        BlobContainerName = container.Name,
-                        BlobName = blobName,
-                        Resource = "b",
-                        ExpiresOn = expiresOn
-                    };
-                    sasBuilder.SetPermissions(BlobSasPermissions.Read);
-
-                    var storageAccountName = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountName)
-                        ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_NAME' is not set.");
-                    var storageAccountKey = Environment.GetEnvironmentVariable(EnvironmentVariables.StorageAccountKey) 
-                        ?? throw new InvalidOperationException("Environment variable 'AZURE_STORAGE_ACCOUNT_KEY' is not set.");
-                    StorageSharedKeyCredential credential = new(
-                        storageAccountName,
-                        storageAccountKey
-                    );
-                    var sasToken = sasBuilder.ToSasQueryParameters(credential).ToString();
-                    sasUrl = $"{blob.Uri}?{sasToken}";
-                }
+                string? sasUrl = SasTokenHelper.GenerateSasUrl(container, a.ImageUrl, storageAccountName, storageAccountKey);
 
                 return new
                 {

--- a/Api/SasTokenHelper.cs
+++ b/Api/SasTokenHelper.cs
@@ -1,0 +1,42 @@
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using System;
+using System.IO;
+
+namespace Api;
+
+public static class SasTokenHelper
+{
+    public static string? GenerateSasUrl(
+        BlobContainerClient container,
+        string? imageUrl,
+        string storageAccountName,
+        string storageAccountKey)
+    {
+        if (string.IsNullOrWhiteSpace(imageUrl))
+        {
+            return null;
+        }
+
+        string blobName = Path.GetFileName(new Uri(imageUrl).AbsolutePath);
+        BlobClient blob = container.GetBlobClient(blobName);
+
+        var expiresOn = DateTimeOffset.UtcNow.AddMinutes(30);
+        var sasBuilder = new BlobSasBuilder
+        {
+            BlobContainerName = container.Name,
+            BlobName = blobName,
+            Resource = "b",
+            ExpiresOn = expiresOn
+        };
+        sasBuilder.SetPermissions(BlobSasPermissions.Read);
+
+        StorageSharedKeyCredential credential = new(
+            storageAccountName,
+            storageAccountKey
+        );
+        var sasToken = sasBuilder.ToSasQueryParameters(credential).ToString();
+        return $"{blob.Uri}?{sasToken}";
+    }
+}

--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -43,6 +43,7 @@
 </section>
 
 <script>
+  import { calculateAge } from '../../utils/dateUtils';
   const toggle = document.getElementById('add-alpaka-toggle');
   const lightbox = document.getElementById('alpaka-lightbox');
   const closeBtn = document.getElementById('close-alpaka-form');
@@ -162,18 +163,6 @@
     } catch (error) {
       console.error('Failed to load alpacas:', error);
     }
-  }
-
-  function calculateAge(geburtsdatum: string | number | Date) {
-    const birth = new Date(geburtsdatum);
-    const now = new Date();
-    let years = now.getFullYear() - birth.getFullYear();
-    let months = now.getMonth() - birth.getMonth();
-    if (months < 0) {
-      years--;
-      months += 12;
-    }
-    return `${years} J ${months} M`;
   }
 
   loadAlpakas();

--- a/src/components/dashboard/Alpakas.astro
+++ b/src/components/dashboard/Alpakas.astro
@@ -119,9 +119,13 @@
       const alpacas = await res.json();
       list.innerHTML = ''; // Clear existing rows before adding new ones
 
-      alpacas.forEach((alpaca: { Geburtsdatum: string; ImageUrl: string | null; Name: string; }) => {
+      alpacas.forEach((alpaca: { Id: string; Geburtsdatum: string; ImageUrl: string | null; Name: string; }) => {
         const row = document.createElement('tr');
         row.className = 'alpaka-item';
+        row.dataset.id = alpaca.Id;
+        row.addEventListener('click', () => {
+          window.location.href = `/dashboard/alpakas/${alpaca.Id}`;
+        });
 
         const age = calculateAge(alpaca.Geburtsdatum);
 

--- a/src/pages/dashboard/alpakas/[id].astro
+++ b/src/pages/dashboard/alpakas/[id].astro
@@ -1,6 +1,13 @@
 ---
 import DashboardLayout from '../../../layouts/DashboardLayout.astro';
-const { id } = Astro.params;
+const { id } = Astro.params; 
+// This 'id' is used by Astro to interpolate into the client script below.
+
+export async function getStaticPaths() {
+  // Return an empty array because the alpaka IDs are not known at build time.
+  // The page will be rendered on the client side using the ID from the URL.
+  return [];
+}
 ---
 
 <DashboardLayout title="Alpaka Details">
@@ -12,12 +19,16 @@ const { id } = Astro.params;
 </DashboardLayout>
 
 <script>
+  import { calculateAge } from '../../../utils/dateUtils';
   const id = "${id}";
   async function loadAlpaka() {
     try {
       const res = await fetch(`/api/dashboard/alpakas/${id}`);
       if (!res.ok) {
-        document.getElementById('alpaka-detail').textContent = 'Fehler beim Laden';
+        const detail = document.getElementById('alpaka-detail');
+        if (detail) {
+          detail.textContent = 'Fehler beim Laden';
+        }
         return;
       }
       const alpaka = await res.json();
@@ -35,18 +46,6 @@ const { id } = Astro.params;
     } catch (e) {
       console.error(e);
     }
-  }
-
-  function calculateAge(geburtsdatum) {
-    const birth = new Date(geburtsdatum);
-    const now = new Date();
-    let years = now.getFullYear() - birth.getFullYear();
-    let months = now.getMonth() - birth.getMonth();
-    if (months < 0) {
-      years--;
-      months += 12;
-    }
-    return `${years} J ${months} M`;
   }
 
   loadAlpaka();

--- a/src/pages/dashboard/alpakas/[id].astro
+++ b/src/pages/dashboard/alpakas/[id].astro
@@ -1,0 +1,88 @@
+---
+import DashboardLayout from '../../../layouts/DashboardLayout.astro';
+const { id } = Astro.params;
+---
+
+<DashboardLayout title="Alpaka Details">
+  <section class="alpaka-detail-page section">
+    <div class="container">
+      <div id="alpaka-detail" class="alpaka-detail loading">Lade Daten...</div>
+    </div>
+  </section>
+</DashboardLayout>
+
+<script>
+  const id = "${id}";
+  async function loadAlpaka() {
+    try {
+      const res = await fetch(`/api/dashboard/alpakas/${id}`);
+      if (!res.ok) {
+        document.getElementById('alpaka-detail').textContent = 'Fehler beim Laden';
+        return;
+      }
+      const alpaka = await res.json();
+      const detail = document.getElementById('alpaka-detail');
+      if (detail) {
+        const age = calculateAge(alpaka.Geburtsdatum);
+        detail.classList.remove('loading');
+        detail.innerHTML = `
+          ${alpaka.ImageUrl ? `<img class="alpaka-photo" src="${alpaka.ImageUrl}" alt="${alpaka.Name}" />` : ''}
+          <h2>${alpaka.Name}</h2>
+          <p>Geburtsdatum: ${new Date(alpaka.Geburtsdatum).toLocaleDateString('de-AT')}</p>
+          <p>Alter: ${age}</p>
+        `;
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function calculateAge(geburtsdatum) {
+    const birth = new Date(geburtsdatum);
+    const now = new Date();
+    let years = now.getFullYear() - birth.getFullYear();
+    let months = now.getMonth() - birth.getMonth();
+    if (months < 0) {
+      years--;
+      months += 12;
+    }
+    return `${years} J ${months} M`;
+  }
+
+  loadAlpaka();
+</script>
+
+<style>
+  .alpaka-detail {
+    background-color: var(--schurwolle);
+    color: var(--taubenblau);
+    padding: 2rem;
+    border-radius: 0.5rem;
+    text-align: center;
+  }
+  .alpaka-photo {
+    max-width: 20rem;
+    width: 100%;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  .loading {
+    font-weight: 600;
+  }
+  .loading::after {
+    content: '';
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    margin-left: 0.5rem;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    animation: spin 0.75s linear infinite;
+  }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,11 @@
+export function calculateAge(geburtsdatum: string | number | Date): string {
+  const birth = new Date(geburtsdatum);
+  const now = new Date();
+  let years = now.getFullYear() - birth.getFullYear();
+  let months = now.getMonth() - birth.getMonth();
+  if (months < 0) {
+    years--;
+    months += 12;
+  }
+  return `${years} J ${months} M`;
+}


### PR DESCRIPTION
## Summary
- add new API endpoint `get-alpaka` to retrieve details for a single alpaca
- make alpaca rows in dashboard clickable and navigate to detail page
- add new dynamic page `/dashboard/alpakas/[id]` to display alpaca information

## Testing
- `npm run build` *(fails: astro not found)*
- `dotnet build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845415c1afc832786f052e9c66ac3dd