### PR TITLE
Add skip link for accessibility

### DIFF
--- a/src/website/src/layouts/DashboardLayout.astro
+++ b/src/website/src/layouts/DashboardLayout.astro
@@ -20,8 +20,11 @@ const { title } = Astro.props;
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300;400&display=swap" rel="stylesheet" />
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
     <DashboardNavbar />
-    <slot />
+    <main id="main-content">
+      <slot />
+    </main>
   </body>
 </html>
 

--- a/src/website/src/layouts/Layout.astro
+++ b/src/website/src/layouts/Layout.astro
@@ -21,8 +21,11 @@ const { title } = Astro.props;
                <Head title={title} />
        </head>
         <body>
+                <a href="#main-content" class="skip-link">Zum Inhalt springen</a>
                 <Navbar />
-                <slot />
+                <main id="main-content">
+                        <slot />
+                </main>
                 <Footer />
         </body>
 </html>

--- a/src/website/src/styles/global.css
+++ b/src/website/src/styles/global.css
@@ -59,3 +59,19 @@ h1, h2, h3, h4, h5, h6 {
   text-decoration: underline;
   color: inherit;
 }
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  background-color: var(--weiss);
+  color: var(--taubenblau);
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add skip navigation link in Layout
- add same skip link to Dashboard layout
- style `.skip-link` in global CSS

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b07d5bd5083278b8e7b7cf5ed8919