### PR TITLE
Improve focus styling for nav and buttons

### DIFF
--- a/src/website/src/components/DashboardNavbar.astro
+++ b/src/website/src/components/DashboardNavbar.astro
@@ -75,6 +75,12 @@ import Logo from "../images/AS_Symbolik_Backstein.svg";
     color: var(--taubenblau);
     font-weight: 600;
   }
+
+  .nav-links a:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--bluetenhonig);
+    border-radius: 0.25rem;
+  }
   .app-link {
     margin-left: 1rem;
     text-decoration: none;

--- a/src/website/src/components/Navbar.astro
+++ b/src/website/src/components/Navbar.astro
@@ -59,6 +59,12 @@ import Logo from "../images/AS_Symbolik_Schwarz.svg";
     font-weight: 600;
   }
 
+  .nav-links a:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--bluetenhonig);
+    border-radius: 0.25rem;
+  }
+
   .nav-toggle {
     display: none;
     background: none;

--- a/src/website/src/styles/global.css
+++ b/src/website/src/styles/global.css
@@ -55,6 +55,11 @@ h1, h2, h3, h4, h5, h6 {
   text-decoration: none;
 }
 
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bluetenhonig);
+}
+
 .link {
   text-decoration: underline;
   color: inherit;


### PR DESCRIPTION
## Summary
- add custom focus style to `.btn`
- show focus state for header nav links and dashboard nav links

## Testing
- `npm run build` *(fails: astro not installed)*
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684b082bf64483278094d33e4ad0405c