### PR TITLE
Fix alpaca grid alignment on desktop

### DIFF
--- a/src/website/src/components/Alpakas.astro
+++ b/src/website/src/components/Alpakas.astro
@@ -59,7 +59,14 @@ import Antonio from '../images/alpakas/antonio.jpeg';
 
   @media (min-width: 768px) {
     .alpaca-grid {
-      grid-template-columns: repeat(3, 1fr);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      justify-content: center;
+    }
+
+    .alpaca-item {
+      flex: 0 0 calc(33.333% - 2rem);
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- ensure the alpaca overview grid centers on desktop

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_685798c0bb748327a98aff6c14d76a74